### PR TITLE
bugfix when captured parameter had the same name as the controller

### DIFF
--- a/lib/batch_api/operation/rack.rb
+++ b/lib/batch_api/operation/rack.rb
@@ -15,7 +15,7 @@ module BatchApi
 
         @method = op["method"] || "get"
         @url = op["url"]
-        @params = op["params"] || {}
+        @params = op["params"] || ActiveSupport::HashWithIndifferentAccess.new
         @headers = op["headers"] || {}
         @options = op
 

--- a/spec/dummy/app/controllers/endpoints_controller.rb
+++ b/spec/dummy/app/controllers/endpoints_controller.rb
@@ -12,6 +12,10 @@ class EndpointsController < ApplicationController
    render json: {result: params[:captured]}
   end
 
+  def process_end_point
+    render json: {result: params[:endpoint]}
+  end
+
   def post
     cookies["POST"] = "tschussikowski"
     response.headers["POST"] = "guten tag"

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -4,7 +4,7 @@ Dummy::Application.routes.draw do
   get "/endpoint" => "endpoints#get"
   get "/endpoint/error" => "endpoints#error"
   get "/endpoint/capture/:captured" => "endpoints#capture"
-
+  get "/endpoint/process_end_point/:endpoint" => "endpoints#process_end_point"
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/spec/rack-integration/shared_examples.rb
+++ b/spec/rack-integration/shared_examples.rb
@@ -120,6 +120,12 @@ shared_examples_for "integrating with a server" do
     method: "get"
   } }
 
+  let(:process_end_point_request) { {
+      url: "/endpoint/process_end_point/#{parameter}",
+      method: "get"
+  } }
+
+
   let(:parameter_result) { {
     body: {
       "result" => parameter.to_s
@@ -152,7 +158,8 @@ shared_examples_for "integrating with a server" do
         parameter_request,
         silent_request,
         failed_silent_request,
-        get_by_default_request
+        get_by_default_request,
+        process_end_point_request
       ],
       sequential: true
     }.to_json, "CONTENT_TYPE" => "application/json"
@@ -193,6 +200,18 @@ shared_examples_for "integrating with a server" do
     describe "the response" do
       before :each do
         @result = JSON.parse(response.body)["results"][4]
+      end
+
+      it "properly parses the URL segment as a paramer" do
+        expect(@result["body"]).to eq(parameter_result[:body])
+      end
+    end
+  end
+
+  context "for a request with parameters with the same name as the controller" do
+    describe "the response" do
+      before :each do
+        @result = JSON.parse(response.body)["results"][8]
       end
 
       it "properly parses the URL segment as a paramer" do

--- a/spec/support/sinatra_app.rb
+++ b/spec/support/sinatra_app.rb
@@ -24,6 +24,11 @@ class SinatraApp < Sinatra::Base
     {result: params[:captured]}.to_json
   end
 
+  get "/endpoint/process_end_point/:endpoint" do
+    content_type :json
+    {result: params[:endpoint]}.to_json
+  end
+
   post "/endpoint" do
     headers["POST"] = "guten tag"
     headers["REQUEST_HEADERS"] = header_output


### PR DESCRIPTION
if there was not parameters given to the rest call, and if the 
captured parameter had the same name as the controller, the controller
could not access to the parameter value because parameter[:endpoint] was
returning the endpoints parameters
